### PR TITLE
section内の要素が上下中央に来るようにした

### DIFF
--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -20,7 +20,9 @@ html, body {
 
 @media screen and (min-width: 480px) {
 section {
-  height: 100vh;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
 }
 }
 

--- a/src/scss/index.scss
+++ b/src/scss/index.scss
@@ -26,15 +26,19 @@ section {
 }
 }
 
-.first-section {
-  background: #FFFFBB;
-}
-
 .section-content {
   padding: 2.0em;
   width: 70%;
   margin-left: auto;
   margin-right: auto;
+}
+
+.first-section {
+  background: #FFFFBB;
+  .section-content{
+    background: white;
+    background: rgba(255,255,255,.3);
+  }
 }
 
 .second-section {


### PR DESCRIPTION
## 概要
section内の要素がPC画面の場合上下中央に来るようにした

## 動機
でかい画面だと下が余って気になったのでやってみました．

## 懸念事項
- CSSが非対応のブラウザとかあるかもしれない
- デザインのセンスが絶望的にないのでダサい

## 備考
あくまで一時的なFixということで，コンテンツ埋めてから見た目しっかり整えたい

## らぁらちゃん
![image](https://user-images.githubusercontent.com/10114717/35769131-be1a7bf6-0949-11e8-8b35-eb614128cca5.png)
