### PR TITLE
Worksのレイアウトをいい感じにする

### DIFF
--- a/assets/css/util.scss
+++ b/assets/css/util.scss
@@ -16,3 +16,7 @@
 .wf-roundedmplus1c * {
   font-family: "Rounded Mplus 1c";
 }
+
+.hidden{
+  display:none
+}

--- a/components/Works.vue
+++ b/components/Works.vue
@@ -2,8 +2,8 @@
   <section class="works-section" id="works">
     <div class="section-content wf-roundedmplus1c">
       <h1 class="section-heading">成果物</h1>
-      <ul class="events">
-        <li v-for="event in history.events.reverse()" :key="event.times">
+      <ul :class="['events' , isOpen ? 'is-open' : '']">
+        <li v-for="event in revesedEvents" :key="event.times">
           <span class="event-title">{{event.title}}</span>
           <ul class="works">
             <li v-for="work in event.works" :key="work.id">
@@ -31,6 +31,9 @@
           </ul>
         </li>
       </ul>
+      <div :class="['readmore', isOpen ? 'hidden' : '' ]">
+        <a class="button button-primary" v-on:click="isOpen = true">続きを読む</a>
+      </div>
     </div>
   </section>
 </template>
@@ -38,6 +41,10 @@
 <script>
 export default {
   props: ['history'],
+  data: function(){ return { isOpen:false } },
+  computed: {
+    revesedEvents(){ return this.history.events.slice().reverse() }
+  }
 }
 </script>
 
@@ -58,10 +65,13 @@ export default {
 }
 
 .events {
-  overflow-y: scroll;
-  /*max-height: 55vh;*/
+  overflow-y: hidden;
+  max-height: 55vh;
   .event-title{
     font-size: 2em;
+  }
+  &.is-open{
+    max-height: none;
   }
 }
 
@@ -118,6 +128,12 @@ export default {
     float: left;
     color: #aaa;
   }
+}
+
+.readmore{
+	text-align:center;
+	cursor:pointer;
+	z-index:999;
 }
 
 </style>

--- a/components/Works.vue
+++ b/components/Works.vue
@@ -3,7 +3,7 @@
     <div class="section-content wf-roundedmplus1c">
       <h1 class="section-heading">成果物</h1>
       <ul class="events">
-        <li v-for="event in history.events" :key="event.times">
+        <li v-for="event in history.events.reverse()" :key="event.times">
           <span class="event-title">{{event.title}}</span>
           <ul class="works">
             <li v-for="work in event.works" :key="work.id">
@@ -59,7 +59,7 @@ export default {
 
 .events {
   overflow-y: scroll;
-  max-height: 55vh;
+  /*max-height: 55vh;*/
   .event-title{
     font-size: 2em;
   }


### PR DESCRIPTION
# 概要

- 最近のイベントが上に表示されるようにした
- 展開ボタンですべて見れるようにした

![kapture 2018-10-01 at 15 31 37](https://user-images.githubusercontent.com/10114717/46273124-2796f580-c58f-11e8-8cae-8dabb8595247.gif)

# みれぃ

誕生日おめでとう 🎉 

