### PR TITLE
Scroll to anchor links when a hash fragment is given

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,3 +3,14 @@
     <nuxt/>
   </div>
 </template>
+
+<script>
+export default {
+  mounted() {
+    const hash = this.$route.hash
+    if (hash && hash.match(/^#.+$/)) {
+      this.$scrollTo(hash)
+    }
+  }
+}
+</script>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -18,6 +18,18 @@ module.exports = {
   */
   loading: { color: '#3B8070' },
   /*
+  ** Plugins to load before mounting the App
+  */
+  plugins: [
+    '~plugins/scroll.js',
+  ],
+  /*
+  ** Nuxt.js modules
+  */
+  modules: [
+    'vue-scrollto/nuxt',
+  ],
+  /*
   ** Build configuration
   */
   build: {
@@ -36,5 +48,5 @@ module.exports = {
     },
     vendor: ['axios']
   },
-  router: { base: '/' }
+  router: { base: '/' },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3683,6 +3683,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bezier-easing": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
+      "integrity": "sha1-wE3+i5JtbsrKGBPWn/F5t8ICXYY="
+    },
     "bfj": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-6.1.2.tgz",
@@ -12654,6 +12659,14 @@
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.3.4.tgz",
       "integrity": "sha512-SdKRBeoXUjaZ9R/8AyxsdTqkOfMcI5tWxPZOUX5Ie1BTL5rPSZ0O++pbiZCeYeythiZIdLEfkDiQPKIaWk5hDg=="
+    },
+    "vue-scrollto": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/vue-scrollto/-/vue-scrollto-2.18.1.tgz",
+      "integrity": "sha512-JojeVOP1Z50Jt0OCOd61jRRRF8TrNvPAzF4LAKwkTEZnt30mpDd48aDZZOEPD3l6z2PybOyUGFT/FNWfTtFv9w==",
+      "requires": {
+        "bezier-easing": "2.1.0"
+      }
     },
     "vue-server-renderer": {
       "version": "2.6.11",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "precommit": "npm run lint"
   },
   "dependencies": {
-    "nuxt": "2.13.3"
+    "nuxt": "2.13.3",
+    "vue-scrollto": "^2.18.1"
   },
   "devDependencies": {
     "axios": "0.19.2",

--- a/plugins/scroll.js
+++ b/plugins/scroll.js
@@ -1,0 +1,4 @@
+import Vue from 'vue';
+import VueScrollTo from 'vue-scrollto';
+
+Vue.use(VueScrollTo)


### PR DESCRIPTION
URLのフラグにanchorが含まれる際、ロード時にanchorまでスクロールするように変更しました。

e.g. `https://prickathon.github.io/#contact`
